### PR TITLE
wait to gather kubeconfig

### DIFF
--- a/kcli_plan.yml
+++ b/kcli_plan.yml
@@ -28,3 +28,8 @@
     path: /root/openshift_pull.json
   scripts:
   - deploy.sh
+{% if installer_wait %}
+  finishfiles:
+  - origin: /root/.kcli/clusters/{{ cluster }}/auth/kubeconfig
+    path: kubeconfig.{{ cluster }}
+{% endif %}


### PR DESCRIPTION
This allows to retrieve kubeconfig from installer vm when installer_wait is set