### PR TITLE
update sno to latest kcli

### DIFF
--- a/01_create_iso.sh
+++ b/01_create_iso.sh
@@ -6,5 +6,5 @@ mv oc /root/bin/oc
 cd /var/www/html
 kcli create cluster openshift --paramfile /root/sno_params.yml {{ cluster }}
 
-chmod +r {{ cluster }}.iso
-restorecon {{ cluster }}.iso
+chmod +r {{ cluster }}-sno.iso
+restorecon {{ cluster }}-sno.iso

--- a/racadm.sh
+++ b/racadm.sh
@@ -2,7 +2,7 @@ CLUSTER=$1
 SERVER=$2
 USER=$3
 PASSWORD=$4
-ISO_URL="http://$(hostname -I | cut -f1 -d" " | xargs)/$CLUSTER.iso"
+ISO_URL="http://$(hostname -I | cut -f1 -d" " | xargs)/$CLUSTER-sno.iso"
 /opt/dell/srvadmin/bin/idracadm7 -r $SERVER -u $USER -p $PASSWORD remoteimage -s &&\
 /opt/dell/srvadmin/bin/idracadm7 -r $SERVER -u $USER -p $PASSWORD remoteimage -d &&\
 /opt/dell/srvadmin/bin/idracadm7 -r $SERVER -u $USER -p $PASSWORD remoteimage -c -l $ISO_URL &&\

--- a/sno_params.yml
+++ b/sno_params.yml
@@ -6,6 +6,7 @@ masters: 1
 workers: 0
 sno: true
 sno_dns: true
+sno_wait: false
 pull_secret: /root/openshift_pull.json
 {% if api_ip != None %}
 api_ip: {{ api_ip }}


### PR DESCRIPTION
change workflow since latest kcli generates the sno image as $CLUSTER-sno.iso and add a variable sno_wait which defaults to True